### PR TITLE
Update create-event.html

### DIFF
--- a/frontend/create-event.html
+++ b/frontend/create-event.html
@@ -33,7 +33,7 @@
 
    <div class="form-row">
      <div class="form-group">
-       <input id="event-date" type="date">
+       <input id="event-date" type="date" max="9999-12-31">
      </div>
      <div class="form-group">
        <input id="event-time" type="time">


### PR DESCRIPTION
FIxed the bug where the year of the date of an event could be 5 digits. This is related to issue #58.