### PR TITLE
DEBUG - Event Creation - Prevent Past Dates

### DIFF
--- a/frontend/createevent.js
+++ b/frontend/createevent.js
@@ -1,0 +1,10 @@
+
+    //Block Past Dates
+    const selectedDate = new Date(date);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    if (selectedDate < today) {
+    alert("⚠️ You cannot select a past date for the event!");
+    return;
+    }
+


### PR DESCRIPTION
This debug relates to bug #78

Create Event JS has been modified to send an alert and prevent the event creation when a user tries to create an event past today's date at time 00:00:00.