### PR TITLE
DEBUG - Event Creation - Prevent Past Dates + Negative Ticketing

### DIFF
--- a/frontend/createevent.js
+++ b/frontend/createevent.js
@@ -17,6 +17,13 @@ if (createBtn) {
       return;
     }
 
+    // Block invalid capacities
+    if (capacity <= 0) {
+    alert("⚠️ Ticket capacity must be greater than 0!");
+    return;
+    }
+
+
     //Block Past Dates
     const selectedDate = new Date(date);
     const today = new Date();


### PR DESCRIPTION
This debug relates to bugs #78 and #77 
A previous PR attempt was cancelled due to an outdated branch getting merged (selmabeds). 

1. Create Event JS has been modified to send an alert and prevent the event creation when a user tries to create an event past today's date at time 00:00:00.

2. Create Event JS has been modified to send an alert and prevent the event creation when a user tries to create an event with less than a ticket available