### PR TITLE
#82 Hide Dashboard from students/logged out + Hide Event Creation from Non-Admin/Organ (Previously + Role selection on Create Account)

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -52,5 +52,19 @@
   <script src="signout.js"></script>
   <script src="index_role.js"></script>
 
+  <!-- Hide create event from non-admin/organ users--> 
+   <script> 
+    fetch('/user-profile') 
+      .then(res => res.json()) 
+      .then(user => { 
+        if (!["organizer", "admin"].includes(user.role)) { 
+          document.querySelector('a[href="create-event.html"]').style.display = "none"; 
+        } 
+      }) 
+      .catch(() => { 
+        // not logged in 
+        document.querySelector('a[href="create-event.html"]').style.display = "none"; }); 
+    </script>
+
 </body>
 </html>

--- a/frontend/index_role.js
+++ b/frontend/index_role.js
@@ -20,6 +20,11 @@ document.addEventListener("DOMContentLoaded", async () => {
   try {
     if (!userRole) userRole = await getUserRoleFromServer();
 
+    // Hide dashboard from student NavBar
+    if (userRole === "student") {
+      dashboardLink.style.display = "none";
+    }
+
     let dashboardHref = "/account";
     if (userRole === "organizer") dashboardHref = "/organizerdashboard";
     else if (userRole === "admin") dashboardHref = "/admindashboard";
@@ -29,6 +34,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     dashboardLink.style.opacity = "1";
   } catch (err) {
     console.warn("Role detection failed:", err);
+    
+    //Hide dashboard from logged out users
     dashboardLink.style.display = "none";
   }
 });


### PR DESCRIPTION
**EDIT: This PR has been requested to be modified and has been changed. Please refer to the comments below.** 

This PR is to complete the issue #82.

Changes done:


**1. Account Creation (create.html and index.js):**

- Frontend: Added dropdown role selection
- Backend: Added validation requiring role selection with no default assignment
- DB: Stored selected role in MongoDB when creating new account

**2. NavBar Behaviour**

- Dashboard link is now hidden from Students and non-logged users.
- Organizers and Admins retain access to their respctive dashboards. 
Note: index_role.js already has the code to handle this, now that role is a requirement in account creation. 

**3. Event Creation Access Control (index.js + account.html)**

- Frontend: Hid "Create Event option from non-admin/org users.
- Backend: Restricted Event Creation from non-admin/org users (added server-side enforcement so they cannot POST)

**4. Styling (style.css)**

- Matched role dropdown from event creation to the other input fields; Ignored the already existing role css for aesthetic purposes.


**Testing Performed before PR:**

- Verified new account creation for each role type.

- Confirmed correct redirection and navbar visibility per role.

- Confirmed students and non-logged users cannot create events.

- Verified event listing remains visible for all users.

